### PR TITLE
Change role_id in hiring manager to listing_id

### DIFF
--- a/role-skill-match-app/app/Models/Hiring_Manager.php
+++ b/role-skill-match-app/app/Models/Hiring_Manager.php
@@ -27,5 +27,5 @@ class Hiring_Manager extends Model
         return $this->belongsTo(Role_Listing::class, 'role_id');
     }
 
-    protected $primaryKey = ['role_id', 'staff_id'];
+    protected $primaryKey = ['listing_id', 'staff_id'];
 }

--- a/role-skill-match-app/database/migrations/2023_09_17_142313_create_role_listing_table.php
+++ b/role-skill-match-app/database/migrations/2023_09_17_142313_create_role_listing_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
             $table->Softdeletes();
 
             // Foreign Keys
-            $table->foreign('role_id')->references('role_id')->on('hiring_manager');
+            //$table->foreign('listing_id')->references('listing_id')->on('hiring_manager');
             $table->foreign('department_id')->references('department_id')->on('department');
             $table->foreign('country_id')->references('country_id')->on('country');
             $table->foreign('created_by')->references('staff_id')->on('staff');

--- a/role-skill-match-app/database/migrations/2023_09_17_142314_create_hiring_manager_table.php
+++ b/role-skill-match-app/database/migrations/2023_09_17_142314_create_hiring_manager_table.php
@@ -12,16 +12,16 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('hiring_manager', function (Blueprint $table) {
-            $table->unsignedInteger('role_id');
+            $table->unsignedInteger('listing_id');
             $table->unsignedInteger('staff_id');
             $table->timestamps();
             $table->Softdeletes();
             // Foreign Keys
-            $table->foreign('role_id')->references('role_id')->on('role');
+            $table->foreign('listing_id')->references('listing_id')->on('role_listing');
             $table->foreign('staff_id')->references('staff_id')->on('staff');
 
             // Composite Primary Keys
-            $table->primary(['role_id', 'staff_id']);
+            $table->primary(['listing_id', 'staff_id']);
         });
     }
 

--- a/role-skill-match-app/database/seeders/HiringManagerSeeder.php
+++ b/role-skill-match-app/database/seeders/HiringManagerSeeder.php
@@ -19,7 +19,7 @@ class HiringManagerSeeder extends Seeder
         // TODO: Will add in role_id when we modify the role table into 1. Full roles 2. Current Role 3. Role listings
         // currently populated with random role_id, to test inputting data into D
         DB::table('hiring_manager')->insert([
-            ['role_id' => 1, 'staff_id' => 6, 'created_at' => now(), 'updated_at' => now()],
+            ['listing_id' => 1, 'staff_id' => 6, 'created_at' => now(), 'updated_at' => now()],
             // Add more permissions here
         ]);
     }


### PR DESCRIPTION
## Pull Request Description
Change role_id of hiring_manager table to listing_id. Removed code where listing_id in role_listing was referencing hiring_manager. Renamed create role_listing migration file so that it runs before create hiring_manager

