### PR TITLE
Quick bugfix on work_arrangement value for create-role

### DIFF
--- a/role-skill-match-app/app/Http/Controllers/RoleController.php
+++ b/role-skill-match-app/app/Http/Controllers/RoleController.php
@@ -173,11 +173,11 @@ class RoleController extends Controller
         $work_arrangements = [
             [
                 'id' => 1,
-                'name' => 'Full-time',
+                'name' => 'Part-time',
             ],
             [
                 'id' => 2,
-                'name' => 'Part-time',
+                'name' => 'Full-time',
             ],
         ];
 


### PR DESCRIPTION
Quick bugfix w/ standardized work_arrangement field to the correct value of: 
1 = 'Part-Time'
2 = 'Full-Time'

## Pull Request Description

Bugfix for RL-01 Create Open Role Listing

## Checklist (Definition of Done)

- [x] Unit tests passed
- [x] Code reviewed
- [x] Acceptance criteria met
- [x] Test cases passed
- [x] C4 diagram checked
- [x] Product owner accepted

## Screenshots (if applicable)

![image](https://github.com/jeezusplays/IS212-G6T6/assets/111420736/703a656e-c4c1-4057-a8d3-48ff387b5439)
